### PR TITLE
Adding separate lang string for each graphtype. 

### DIFF
--- a/block_ace.php
+++ b/block_ace.php
@@ -88,6 +88,7 @@ class block_ace extends block_base {
 
         switch ($type) {
             case 'student':
+                $helptext = get_string('studenttitlehelper', 'block_ace');
                 $userid = $this->get_userid_from_contextid();
 
                 if (!has_capability('local/ace:viewown', $this->page->context)) {
@@ -170,6 +171,7 @@ EOF;
 
                 break;
             case 'course':
+                $helptext = get_string('coursetitlehelper', 'block_ace');
                 if ($this->page->course->id == SITEID) {
                     return $this->content;
                 }
@@ -182,6 +184,7 @@ EOF;
                 $text = html_writer::div($graph, 'teachergraph');
                 break;
             case 'studentwithtabs':
+                $helptext = get_string('studentwithtabstitlehelper', 'block_ace');
                 $userid = $this->get_userid_from_contextid();
 
                 if (!has_capability('local/ace:viewown', $this->page->context)) {
@@ -194,18 +197,21 @@ EOF;
                 $text = local_ace_student_full_graph($userid, $courseid);
                 break;
             case 'teachercourse':
+                $helptext = get_string('teachercoursetitlehelper', 'block_ace');
                 if (!has_capability('local/ace:viewown', $this->page->context)) {
                     return $this->content;
                 }
                 $text = local_ace_teacher_course_graph($USER->id);
                 break;
             case 'activity':
+                $helptext = get_string('activitytitlehelper', 'block_ace');
                 if (!has_capability('local/ace:view', $this->page->context)) {
                     return $this->content;
                 }
                 $text = local_ace_course_module_engagement_graph($this->page->context->instanceid);
                 break;
             case 'studentteachergraph':
+                $helptext = get_string('studentteachergraphtitlehelper', 'block_ace');
                 $courseid = optional_param('course', 0, PARAM_INT);
                 $userid = $this->get_userid_from_contextid();
                 if ($this->page->context->contextlevel == CONTEXT_USER && $userid != $USER->id
@@ -221,11 +227,13 @@ EOF;
             default:
                 break;
         }
-
-        $helper = '<a class="btn btn-link p-0" role="button" data-container="body" data-toggle="popover" data-placement="right"
-        data-content="<p>'. get_string('titlehelper', 'block_ace').'</p> "
-data-html="true" tabindex="0" data-trigger="focus" data-original-title="" title="">
-        <i class="icon fa fa-question-circle text-info fa-fw " title="'. get_string('titlehelper', 'block_ace').'" role="img" aria-label=""></i></a>';
+        $helper = '';
+        if (!empty($helptext)) {
+            $helper = '<a class="btn btn-link p-0" role="button" data-container="body" data-toggle="popover" data-placement="right"
+            data-content="<p>'. $helptext.'</p> "
+    data-html="true" tabindex="0" data-trigger="focus" data-original-title="" title="">
+            <i class="icon fa fa-question-circle text-info fa-fw " title="'. $helptext.'" role="img" aria-label=""></i></a>';
+        }
 
         $header = html_writer::tag('h5', $this->title.$helper,
             ['class' => 'block_ace-card-title']);

--- a/lang/en/block_ace.php
+++ b/lang/en/block_ace.php
@@ -45,5 +45,15 @@ $string['activity'] = 'Activity Engagement';
 $string['switchtolivegraph'] = 'Switch to live graph';
 $string['switchtostaticimage'] = 'Switch to static image';
 $string['studentteachergraph'] = 'Autodetect student vs teacher graph';
-$string['titlehelper'] = "Analytics for Course Engagement (ACE) looks at how much students are engaging with their course materials on LEARN.\n
+$string['studenttitlehelper'] = "";
+$string['coursetitlehelper'] = "Analytics for Course Engagement (ACE) looks at how much students are engaging with their course materials on LEARN.\n
+This ACE Course Dashboard gives you an overview of the level of students' engagement in your course, and how the average engagement level of your students tracks over time.";
+$string['studentwithtabstitlehelper'] = "Analytics forStudent Engagement w/ Course Tabs (ACE) looks at how much students are engaging with their course materials on LEARN.\n
+This ACE Course Dashboard gives you an overview of the level of students' engagement in your course, and how the average engagement level of your students tracks over time.
+";
+$string['teachercoursetitlehelper'] = "Analytics for Teacher Course Engagement (ACE) looks at how much students are engaging with their course materials on LEARN.\n
+This ACE Course Dashboard gives you an overview of the level of students' engagement in your course, and how the average engagement level of your students tracks over time.";
+$string['activitytitlehelper'] = "Analytics for Activity Engagement (ACE) looks at how much students are engaging with their course materials on LEARN.\n
+This ACE Course Dashboard gives you an overview of the level of students' engagement in your course, and how the average engagement level of your students tracks over time.";
+$string['studentteachergraphtitlehelper'] = "Analytics for Autodetect student vs teacher graph (ACE) looks at how much students are engaging with their course materials on LEARN.\n
 This ACE Course Dashboard gives you an overview of the level of students' engagement in your course, and how the average engagement level of your students tracks over time.";


### PR DESCRIPTION
 Hi,

This creates lang strings for each graphtype,  - eg graphtype== 'course' has use the help text string "coursetitlehelper"

It also enable hiding the the help icon on a graph if its lang string is empty.

Regards,
Sumaiya